### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/src/main/java/org/codelibs/curl/Curl.java
+++ b/src/main/java/org/codelibs/curl/Curl.java
@@ -44,8 +44,14 @@ import java.io.File;
  */
 public class Curl {
 
+    /**
+     * The temporary directory used by Curl. It is initialized to the system's temporary directory.
+     */
     public static final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     protected Curl() {
         // nothing
     }
@@ -134,7 +140,38 @@ public class Curl {
      * </ul>
      */
     public enum Method {
-        GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, CONNECT;
+        /**
+         * HTTP GET method.
+         */
+        GET,
+        /**
+         * HTTP POST method.
+         */
+        POST,
+        /**
+         * HTTP PUT method.
+         */
+        PUT,
+        /**
+         * HTTP DELETE method.
+         */
+        DELETE,
+        /**
+         * HTTP HEAD method.
+         */
+        HEAD,
+        /**
+         * HTTP OPTIONS method.
+         */
+        OPTIONS,
+        /**
+         * HTTP TRACE method.
+         */
+        TRACE,
+        /**
+         * HTTP CONNECT method.
+         */
+        CONNECT;
     }
 
 }

--- a/src/main/java/org/codelibs/curl/CurlException.java
+++ b/src/main/java/org/codelibs/curl/CurlException.java
@@ -32,10 +32,22 @@ public class CurlException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new CurlException with the specified detail message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
+     *              (A {@code null} value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
     public CurlException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new CurlException with the specified detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     */
     public CurlException(final String message) {
         super(message);
     }

--- a/src/main/java/org/codelibs/curl/CurlRequest.java
+++ b/src/main/java/org/codelibs/curl/CurlRequest.java
@@ -477,6 +477,9 @@ public class CurlRequest {
      * The RequestProcessor class processes the HTTP request and handles the response.
      */
     public static class RequestProcessor implements Consumer<HttpURLConnection> {
+        /**
+         * The CurlResponse object to store the response.
+         */
         protected CurlResponse response = new CurlResponse();
 
         private final String encoding;

--- a/src/main/java/org/codelibs/curl/CurlResponse.java
+++ b/src/main/java/org/codelibs/curl/CurlResponse.java
@@ -35,6 +35,13 @@ import org.codelibs.curl.io.ContentCache;
 public class CurlResponse implements Closeable {
 
     /**
+     * Constructs a new CurlResponse.
+     */
+    public CurlResponse() {
+        // nothing
+    }
+
+    /**
      * The HTTP status code of the response.
      */
     private int httpStatusCode;

--- a/src/main/java/org/codelibs/curl/io/ContentCache.java
+++ b/src/main/java/org/codelibs/curl/io/ContentCache.java
@@ -65,6 +65,9 @@ import java.util.logging.Logger;
  */
 public class ContentCache implements Closeable {
 
+    /**
+     * The logger for this class.
+     */
     protected static final Logger logger = Logger.getLogger(ContentCache.class.getName());
 
     /**
@@ -77,11 +80,21 @@ public class ContentCache implements Closeable {
      */
     private final File file;
 
+    /**
+     * Constructs a ContentCache with the given byte array data.
+     *
+     * @param data the byte array containing the content
+     */
     public ContentCache(final byte[] data) {
         this.data = data;
         this.file = null;
     }
 
+    /**
+     * Constructs a ContentCache with the given file.
+     *
+     * @param file the file containing the content
+     */
     public ContentCache(final File file) {
         this.data = null;
         this.file = file;

--- a/src/main/java/org/codelibs/curl/io/ContentOutputStream.java
+++ b/src/main/java/org/codelibs/curl/io/ContentOutputStream.java
@@ -50,14 +50,32 @@ import org.apache.commons.io.output.DeferredFileOutputStream;
  */
 public class ContentOutputStream extends DeferredFileOutputStream {
 
+    /**
+     * The logger for this class.
+     */
     protected static final Logger logger = Logger.getLogger(ContentOutputStream.class.getName());
 
+    /**
+     * The prefix for the temporary file name.
+     */
     protected static final String PREFIX = "curl4j-";
 
+    /**
+     * The suffix for the temporary file name.
+     */
     protected static final String SUFFIX = ".tmp";
 
+    /**
+     * A flag indicating whether the file has been retrieved.
+     */
     protected boolean done = false;
 
+    /**
+     * Constructs a ContentOutputStream with a specified threshold and temporary directory.
+     *
+     * @param threshold the threshold in bytes for writing to memory before writing to a file
+     * @param tmpDir the temporary directory to create the file in
+     */
     public ContentOutputStream(final int threshold, final File tmpDir) {
         super(threshold, PREFIX, SUFFIX, tmpDir);
     }


### PR DESCRIPTION
This pull request focuses on improving code documentation across several classes in the `org.codelibs.curl` package. The changes include adding detailed Javadoc comments for constructors, methods, and fields to enhance code readability and maintainability.

### Documentation Improvements:

#### General Enhancements:
* Added Javadoc comments for the `tmpDir` field and the private constructor in `Curl` to clarify its purpose and prevent instantiation. (`src/main/java/org/codelibs/curl/Curl.java`, [src/main/java/org/codelibs/curl/Curl.javaR47-R54](diffhunk://#diff-91211b01856a57ed9a3f8344b92d2fdfaf6e61dfa514f3ab68c82f8241ef0a10R47-R54))
* Included detailed comments for the HTTP methods in the `Method` enum to describe each method's functionality. (`src/main/java/org/codelibs/curl/Curl.java`, [src/main/java/org/codelibs/curl/Curl.javaL137-R174](diffhunk://#diff-91211b01856a57ed9a3f8344b92d2fdfaf6e61dfa514f3ab68c82f8241ef0a10L137-R174))

#### Exception Handling:
* Added Javadoc comments for constructors in `CurlException` to explain their parameters and usage. (`src/main/java/org/codelibs/curl/CurlException.java`, [src/main/java/org/codelibs/curl/CurlException.javaR35-R50](diffhunk://#diff-4e848a2c732b50a308ef0e205ef5aafe13e57ebd4a3d04e6e19f280b85aca70cR35-R50))

#### Response and Request Handling:
* Documented the `response` field in `RequestProcessor` to specify its role in storing HTTP responses. (`src/main/java/org/codelibs/curl/CurlRequest.java`, [src/main/java/org/codelibs/curl/CurlRequest.javaR480-R482](diffhunk://#diff-be368c62ff6fdd639d202a1f536bd23fb8157496b1f5c6d89de334b6fb1919a1R480-R482))
* Added Javadoc for the `CurlResponse` constructor to clarify its initialization. (`src/main/java/org/codelibs/curl/CurlResponse.java`, [src/main/java/org/codelibs/curl/CurlResponse.javaR37-R43](diffhunk://#diff-8bda276760cd65f7a382cb5c26ee80adb7bb237c5ee5ac052d80118650f030e6R37-R43))

#### File and Stream Management:
* Added comments for the `logger` field and constructors in `ContentCache` to describe logging and initialization with byte arrays or files. (`src/main/java/org/codelibs/curl/io/ContentCache.java`, [[1]](diffhunk://#diff-67aa7d2a4f55ad27d8c6c95a8902874fc7a231429cb22cf9664c558185ffc469R68-R70) [[2]](diffhunk://#diff-67aa7d2a4f55ad27d8c6c95a8902874fc7a231429cb22cf9664c558185ffc469R83-R97)
* Documented fields and constructors in `ContentOutputStream` to explain temporary file handling and memory thresholds. (`src/main/java/org/codelibs/curl/io/ContentOutputStream.java`, [src/main/java/org/codelibs/curl/io/ContentOutputStream.javaR53-R78](diffhunk://#diff-537420263afc37a51d79e045a6f330e0499c135d0c0c76c6e05b43109b9b9343R53-R78))