### PR TITLE
Add timeout API, fix HEAD/error stream handling, optimize response

### DIFF
--- a/src/main/java/org/codelibs/curl/CurlRequest.java
+++ b/src/main/java/org/codelibs/curl/CurlRequest.java
@@ -126,6 +126,16 @@ public class CurlRequest {
     private BiConsumer<CurlRequest, HttpURLConnection> connectionBuilder;
 
     /**
+     * The connection timeout in milliseconds. A value of -1 means not set.
+     */
+    protected int connectTimeout = -1;
+
+    /**
+     * The read timeout in milliseconds. A value of -1 means not set.
+     */
+    protected int readTimeout = -1;
+
+    /**
      * Constructs a new CurlRequest with the specified HTTP method.
      *
      * @param method the HTTP method
@@ -368,9 +378,16 @@ public class CurlRequest {
             HttpURLConnection connection = null;
             try {
                 logger.fine(() -> ">>> " + method + " " + finalUrl);
+                @SuppressWarnings("deprecation")
                 final URL u = new URL(finalUrl);
                 connection = open(u);
                 connection.setRequestMethod(method.toString());
+                if (connectTimeout >= 0) {
+                    connection.setConnectTimeout(connectTimeout);
+                }
+                if (readTimeout >= 0) {
+                    connection.setReadTimeout(readTimeout);
+                }
                 if (headerList != null) {
                     for (final String[] values : headerList) {
                         logger.fine(() -> ">>> " + values[0] + "=" + values[1]);
@@ -496,6 +513,19 @@ public class CurlRequest {
     }
 
     /**
+     * Sets the connection and read timeouts for the request.
+     *
+     * @param connectTimeout the connection timeout in milliseconds
+     * @param readTimeout the read timeout in milliseconds
+     * @return this CurlRequest instance
+     */
+    public CurlRequest timeout(final int connectTimeout, final int readTimeout) {
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        return this;
+    }
+
+    /**
      * The RequestProcessor class processes the HTTP request and handles the response.
      */
     public static class RequestProcessor implements Consumer<HttpURLConnection> {
@@ -544,19 +574,23 @@ public class CurlRequest {
             }
             writeContent(() -> {
                 try {
-                    if (con.getResponseCode() < 400) {
+                    if (Method.HEAD.toString().equalsIgnoreCase(con.getRequestMethod())) {
+                        return new ByteArrayInputStream(new byte[0]);
+                    } else if (con.getResponseCode() < 400) {
                         if (GZIP.equals(con.getContentEncoding())) {
                             return new GZIPInputStream(con.getInputStream());
                         } else {
                             return con.getInputStream();
                         }
-                    } else if (Method.HEAD.toString().equalsIgnoreCase(con.getRequestMethod())) {
-                        return new ByteArrayInputStream(new byte[0]);
                     } else {
+                        final InputStream errorStream = con.getErrorStream();
+                        if (errorStream == null) {
+                            return new ByteArrayInputStream(new byte[0]);
+                        }
                         if (GZIP.equals(con.getContentEncoding())) {
-                            return new GZIPInputStream(con.getErrorStream());
+                            return new GZIPInputStream(errorStream);
                         } else {
-                            return con.getErrorStream();
+                            return errorStream;
                         }
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/codelibs/curl/CurlResponse.java
+++ b/src/main/java/org/codelibs/curl/CurlResponse.java
@@ -15,8 +15,6 @@
  */
 package org.codelibs.curl;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -96,17 +94,14 @@ public class CurlResponse implements Closeable {
      * @throws CurlException if an error occurs while accessing the content.
      */
     public String getContentAsString() {
-        final byte[] bytes = new byte[4096];
-        try (BufferedInputStream bis = new BufferedInputStream(getContentAsStream());
-                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            int length = bis.read(bytes);
-            while (length != -1) {
-                if (length != 0) {
-                    baos.write(bytes, 0, length);
-                }
-                length = bis.read(bytes);
+        if (contentCache == null) {
+            if (contentException != null) {
+                throw new CurlException("Failed to access the content.", contentException);
             }
-            return baos.toString(encoding);
+            throw new CurlException("Failed to access the content.");
+        }
+        try {
+            return new String(contentCache.getContentAsBytes(), encoding);
         } catch (final Exception e) {
             throw new CurlException("Failed to access the content.", e);
         }

--- a/src/main/java/org/codelibs/curl/io/ContentCache.java
+++ b/src/main/java/org/codelibs/curl/io/ContentCache.java
@@ -108,6 +108,30 @@ public class ContentCache implements Closeable {
         this.file = file;
     }
 
+    /**
+     * Returns whether the content is cached in memory.
+     *
+     * @return true if the content is in memory, false if it is in a file
+     */
+    public boolean isInMemory() {
+        return data != null;
+    }
+
+    /**
+     * Returns the content as a byte array.
+     * If the content is cached in memory, a clone of the data is returned.
+     * If the content is cached in a file, the file contents are read.
+     *
+     * @return the content as a byte array
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public byte[] getContentAsBytes() throws IOException {
+        if (data != null) {
+            return data.clone();
+        }
+        return Files.readAllBytes(file.toPath());
+    }
+
     @Override
     public void close() throws IOException {
         if (file != null) {

--- a/src/test/java/org/codelibs/curl/CurlRequestTest.java
+++ b/src/test/java/org/codelibs/curl/CurlRequestTest.java
@@ -631,4 +631,152 @@ public class CurlRequestTest {
         assertEquals("TRACE", Method.TRACE.toString());
         assertEquals("CONNECT", Method.CONNECT.toString());
     }
+
+    // --- URL with special characters tests ---
+
+    @Test
+    public void test_UrlWithSpaces() {
+        // ## Arrange ##
+        // URLs with spaces should be accepted (HttpURLConnection is lenient)
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com/path with spaces");
+
+        // ## Assert ##
+        assertNotNull(request);
+        assertEquals(Method.GET, request.method());
+    }
+
+    @Test
+    public void test_UrlWithCurlyBraces() {
+        // ## Arrange ##
+        // URLs with curly braces (e.g., OpenSearch) should be accepted
+        final CurlRequest request = new CurlRequest(Method.GET, "http://localhost:9200/{index}/_search");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    @Test
+    public void test_UrlWithPipe() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com/path?q=a|b");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    @Test
+    public void test_UrlWithUnicode() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com/日本語パス");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    @Test
+    public void test_UrlWithFragment() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com/page#section");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    @Test
+    public void test_UrlWithPort() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://localhost:9200/_cluster/health");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    @Test
+    public void test_UrlWithAuthentication() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://user:pass@example.com/path");
+
+        // ## Assert ##
+        assertNotNull(request);
+    }
+
+    // --- Timeout API tests ---
+
+    @Test
+    public void test_TimeoutDefaults() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com");
+
+        // ## Assert ##
+        // Default timeout values should be -1 (not set)
+        assertEquals(-1, request.connectTimeout);
+        assertEquals(-1, request.readTimeout);
+    }
+
+    @Test
+    public void test_TimeoutSetsValues() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com");
+
+        // ## Act ##
+        final CurlRequest result = request.timeout(5000, 10000);
+
+        // ## Assert ##
+        assertSame(request, result);
+        assertEquals(5000, request.connectTimeout);
+        assertEquals(10000, request.readTimeout);
+    }
+
+    @Test
+    public void test_TimeoutZeroValues() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com");
+
+        // ## Act ##
+        request.timeout(0, 0);
+
+        // ## Assert ##
+        assertEquals(0, request.connectTimeout);
+        assertEquals(0, request.readTimeout);
+    }
+
+    @Test
+    public void test_TimeoutFluentChaining() {
+        // ## Arrange & Act ##
+        final CurlRequest request = new CurlRequest(Method.POST, "http://example.com").header("Content-Type", "application/json")
+                .timeout(3000, 5000).body("{\"key\":\"value\"}");
+
+        // ## Assert ##
+        assertEquals(3000, request.connectTimeout);
+        assertEquals(5000, request.readTimeout);
+        assertNotNull(request.body());
+    }
+
+    @Test
+    public void test_TimeoutNegativeValues() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com");
+
+        // ## Act ##
+        request.timeout(-2, -3);
+
+        // ## Assert ##
+        // Any negative value should be accepted (treated as "not set" in connect())
+        assertEquals(-2, request.connectTimeout);
+        assertEquals(-3, request.readTimeout);
+    }
+
+    @Test
+    public void test_TimeoutOverwrite() {
+        // ## Arrange ##
+        final CurlRequest request = new CurlRequest(Method.GET, "http://example.com");
+
+        // ## Act ##
+        request.timeout(1000, 2000);
+        request.timeout(3000, 4000);
+
+        // ## Assert ##
+        assertEquals(3000, request.connectTimeout);
+        assertEquals(4000, request.readTimeout);
+    }
 }

--- a/src/test/java/org/codelibs/curl/CurlResponseTest.java
+++ b/src/test/java/org/codelibs/curl/CurlResponseTest.java
@@ -253,11 +253,7 @@ public class CurlResponseTest {
             fail("Expected CurlException");
         } catch (CurlException e) {
             assertTrue(e.getMessage().contains("Failed to access the content"));
-            // The cause should be another CurlException from getContentAsStream()
-            assertTrue(e.getCause() instanceof CurlException);
-            CurlException innerException = (CurlException) e.getCause();
-            assertTrue(innerException.getMessage().contains("The content does not exist"));
-            assertSame(exception, innerException.getCause());
+            assertSame(exception, e.getCause());
         }
     }
 
@@ -359,5 +355,170 @@ public class CurlResponseTest {
 
         assertEquals("gzip", response.getHeaderValue("Accept-Encoding"));
         assertEquals("gzip", response.getHeaderValue("ACCEPT-ENCODING"));
+    }
+
+    // --- getContentAsString() optimization tests ---
+
+    @Test
+    public void test_GetContentAsString_InMemoryCache() {
+        // ## Arrange ##
+        String content = "Hello, World!";
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_GetContentAsString_WithDifferentEncoding() {
+        // ## Arrange ##
+        String content = "ISO-8859-1 content";
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("ISO-8859-1");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1)));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_GetContentAsString_NullCache_ThrowsException() {
+        // ## Arrange ##
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+
+        // ## Act & Assert ##
+        try {
+            response.getContentAsString();
+            fail("Expected CurlException");
+        } catch (CurlException e) {
+            assertEquals("Failed to access the content.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_GetContentAsString_NullCache_WithContentException() {
+        // ## Arrange ##
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentException(new IOException("test error"));
+
+        // ## Act & Assert ##
+        try {
+            response.getContentAsString();
+            fail("Expected CurlException");
+        } catch (CurlException e) {
+            assertEquals("Failed to access the content.", e.getMessage());
+            assertNotNull(e.getCause());
+        }
+    }
+
+    @Test
+    public void test_GetContentAsString_EmptyContent() {
+        // ## Arrange ##
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(new byte[0]));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals("", result);
+    }
+
+    @Test
+    public void test_GetContentAsString_UnicodeContent() {
+        // ## Arrange ##
+        String content = "日本語テスト 🎉";
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_GetContentAsString_FileBasedCache() throws IOException {
+        // ## Arrange ##
+        String content = "File-based content test";
+        java.io.File tmpFile = java.io.File.createTempFile("response-test-", ".tmp");
+        tmpFile.deleteOnExit();
+        java.nio.file.Files.write(tmpFile.toPath(), content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(tmpFile));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_GetContentAsString_LargeContent() {
+        // ## Arrange ##
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            sb.append("Line ").append(i).append(": This is a test line with some content.\n");
+        }
+        String content = sb.toString();
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // ## Act ##
+        String result = response.getContentAsString();
+
+        // ## Assert ##
+        assertEquals(content, result);
+    }
+
+    @Test
+    public void test_GetContentAsString_MultipleCallsConsistent() {
+        // ## Arrange ##
+        String content = "consistent content";
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // ## Act & Assert ##
+        assertEquals(content, response.getContentAsString());
+        assertEquals(content, response.getContentAsString());
+    }
+
+    @Test
+    public void test_GetContentAsStream_AfterGetContentAsString() throws IOException {
+        // ## Arrange ##
+        String content = "stream after string";
+        CurlResponse response = new CurlResponse();
+        response.setEncoding("UTF-8");
+        response.setContentCache(new ContentCache(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+        // ## Act ##
+        String str = response.getContentAsString();
+        try (InputStream stream = response.getContentAsStream()) {
+            byte[] buffer = new byte[1024];
+            int bytesRead = stream.read(buffer);
+            String fromStream = new String(buffer, 0, bytesRead, "UTF-8");
+
+            // ## Assert ##
+            assertEquals(content, str);
+            assertEquals(content, fromStream);
+        }
     }
 }

--- a/src/test/java/org/codelibs/curl/io/ContentCacheTest.java
+++ b/src/test/java/org/codelibs/curl/io/ContentCacheTest.java
@@ -337,4 +337,167 @@ public class ContentCacheTest {
             assertEquals(", World!", new String(remaining, 0, remainingBytes, "UTF-8"));
         }
     }
+
+    // --- isInMemory() tests ---
+
+    @Test
+    public void testIsInMemory_WithByteArray() {
+        // ## Arrange ##
+        ContentCache cache = new ContentCache("test".getBytes());
+
+        // ## Assert ##
+        assertTrue(cache.isInMemory());
+    }
+
+    @Test
+    public void testIsInMemory_WithFile() throws IOException {
+        // ## Arrange ##
+        File tmpFile = File.createTempFile("cache-test-", ".tmp");
+        tmpFile.deleteOnExit();
+        ContentCache cache = new ContentCache(tmpFile);
+
+        // ## Assert ##
+        assertFalse(cache.isInMemory());
+    }
+
+    // --- getContentAsBytes() tests ---
+
+    @Test
+    public void testGetContentAsBytes_InMemory() throws IOException {
+        // ## Arrange ##
+        String content = "Hello, World!";
+        byte[] data = content.getBytes("UTF-8");
+        ContentCache cache = new ContentCache(data);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    public void testGetContentAsBytes_InMemory_DefensiveCopy() throws IOException {
+        // ## Arrange ##
+        byte[] data = "original".getBytes("UTF-8");
+        ContentCache cache = new ContentCache(data);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+        result[0] = 'X';
+
+        // ## Assert ##
+        byte[] secondResult = cache.getContentAsBytes();
+        assertArrayEquals("original".getBytes("UTF-8"), secondResult);
+    }
+
+    @Test
+    public void testGetContentAsBytes_FromFile() throws IOException {
+        // ## Arrange ##
+        File tmpFile = File.createTempFile("cache-test-", ".tmp");
+        tmpFile.deleteOnExit();
+        String content = "File content here";
+        java.nio.file.Files.write(tmpFile.toPath(), content.getBytes("UTF-8"));
+        ContentCache cache = new ContentCache(tmpFile);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertEquals(content, new String(result, "UTF-8"));
+    }
+
+    @Test
+    public void testGetContentAsBytes_EmptyData() throws IOException {
+        // ## Arrange ##
+        ContentCache cache = new ContentCache(new byte[0]);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void testGetContentAsBytes_EmptyFile() throws IOException {
+        // ## Arrange ##
+        File tmpFile = File.createTempFile("cache-test-", ".tmp");
+        tmpFile.deleteOnExit();
+        ContentCache cache = new ContentCache(tmpFile);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void testGetContentAsBytes_LargeData() throws IOException {
+        // ## Arrange ##
+        byte[] data = new byte[1024 * 1024]; // 1MB
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 256);
+        }
+        ContentCache cache = new ContentCache(data);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    public void testGetContentAsBytes_BinaryData() throws IOException {
+        // ## Arrange ##
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            data[i] = (byte) i;
+        }
+        ContentCache cache = new ContentCache(data);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    public void testGetContentAsBytes_FromFile_Unicode() throws IOException {
+        // ## Arrange ##
+        File tmpFile = File.createTempFile("cache-test-", ".tmp");
+        tmpFile.deleteOnExit();
+        String content = "日本語テスト Unicode content 🎉";
+        java.nio.file.Files.write(tmpFile.toPath(), content.getBytes("UTF-8"));
+        ContentCache cache = new ContentCache(tmpFile);
+
+        // ## Act ##
+        byte[] result = cache.getContentAsBytes();
+
+        // ## Assert ##
+        assertEquals(content, new String(result, "UTF-8"));
+    }
+
+    @Test
+    public void testGetContentAsBytes_MultipleCallsConsistent() throws IOException {
+        // ## Arrange ##
+        byte[] data = "consistent data".getBytes("UTF-8");
+        ContentCache cache = new ContentCache(data);
+
+        // ## Act & Assert ##
+        assertArrayEquals(cache.getContentAsBytes(), cache.getContentAsBytes());
+        assertArrayEquals(cache.getContentAsBytes(), cache.getContentAsBytes());
+    }
+
+    @Test
+    public void testIsInMemory_WithEmptyByteArray() {
+        // ## Arrange ##
+        ContentCache cache = new ContentCache(new byte[0]);
+
+        // ## Assert ##
+        assertTrue(cache.isInMemory());
+    }
 }

--- a/src/test/java/org/codelibs/curl/io/IOIntegrationTest.java
+++ b/src/test/java/org/codelibs/curl/io/IOIntegrationTest.java
@@ -17,6 +17,7 @@ package org.codelibs.curl.io;
 
 import org.codelibs.curl.Curl;
 import org.codelibs.curl.CurlRequest;
+import org.codelibs.curl.CurlResponse;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -27,13 +28,19 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import static org.codelibs.curl.io.ContentOutputStream.PREFIX;
 import static org.codelibs.curl.io.ContentOutputStream.SUFFIX;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class IOIntegrationTest {
 
@@ -109,5 +116,466 @@ public class IOIntegrationTest {
     private long countTmpFiles() {
         return Arrays.stream(Objects.requireNonNull(Curl.tmpDir.listFiles())).map(File::getName)
                 .filter(s -> s.startsWith(PREFIX) && s.endsWith(SUFFIX)).count();
+    }
+
+    // --- HEAD request logic tests ---
+
+    /**
+     * Mock HttpURLConnection that simulates a HEAD request with configurable status code.
+     */
+    class HeadMockHttpURLConnection extends HttpURLConnection {
+        private final int statusCode;
+
+        HeadMockHttpURLConnection(URL u, int statusCode) {
+            super(u);
+            this.statusCode = statusCode;
+            this.method = "HEAD";
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public int getResponseCode() {
+            return statusCode;
+        }
+
+        @Override
+        public String getRequestMethod() {
+            return "HEAD";
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            throw new AssertionError("HEAD request should not read input stream");
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            throw new AssertionError("HEAD request should not read error stream");
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaderFields() {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Test
+    public void test_HeadRequestWith200_ReturnsEmptyBody() throws Exception {
+        // ## Arrange ##
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.HEAD, "http://dummy", u -> new HeadMockHttpURLConnection(u, 200));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(200, response.getHttpStatusCode());
+            String content = response.getContentAsString();
+            assertEquals("", content);
+        }
+    }
+
+    @Test
+    public void test_HeadRequestWith404_ReturnsEmptyBody() throws Exception {
+        // ## Arrange ##
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.HEAD, "http://dummy", u -> new HeadMockHttpURLConnection(u, 404));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(404, response.getHttpStatusCode());
+            String content = response.getContentAsString();
+            assertEquals("", content);
+        }
+    }
+
+    @Test
+    public void test_HeadRequestWith500_ReturnsEmptyBody() throws Exception {
+        // ## Arrange ##
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.HEAD, "http://dummy", u -> new HeadMockHttpURLConnection(u, 500));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(500, response.getHttpStatusCode());
+            String content = response.getContentAsString();
+            assertEquals("", content);
+        }
+    }
+
+    // --- Null error stream tests ---
+
+    /**
+     * Mock HttpURLConnection that returns null from getErrorStream().
+     */
+    class NullErrorStreamMockHttpURLConnection extends HttpURLConnection {
+        NullErrorStreamMockHttpURLConnection(URL u) {
+            super(u);
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public int getResponseCode() {
+            return 500;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return null; // Simulates server returning no error body
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return null;
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaderFields() {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Test
+    public void test_NullErrorStream_DoesNotThrowNPE() throws Exception {
+        // ## Arrange ##
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new NullErrorStreamMockHttpURLConnection(u));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(500, response.getHttpStatusCode());
+            String content = response.getContentAsString();
+            assertEquals("", content);
+        }
+    }
+
+    // --- Error stream with content tests ---
+
+    /**
+     * Mock HttpURLConnection that returns error body from getErrorStream().
+     */
+    class ErrorBodyMockHttpURLConnection extends HttpURLConnection {
+        private final int statusCode;
+        private final String errorBody;
+
+        ErrorBodyMockHttpURLConnection(URL u, int statusCode, String errorBody) {
+            super(u);
+            this.statusCode = statusCode;
+            this.errorBody = errorBody;
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public int getResponseCode() {
+            return statusCode;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(errorBody.getBytes());
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return null;
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaderFields() {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Test
+    public void test_ErrorResponseWithBody_ReturnsErrorBody() throws Exception {
+        // ## Arrange ##
+        String errorBody = "{\"error\":\"Internal Server Error\"}";
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new ErrorBodyMockHttpURLConnection(u, 500, errorBody));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(500, response.getHttpStatusCode());
+            assertEquals(errorBody, response.getContentAsString());
+        }
+    }
+
+    @Test
+    public void test_404ResponseWithBody_ReturnsErrorBody() throws Exception {
+        // ## Arrange ##
+        String errorBody = "Not Found";
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new ErrorBodyMockHttpURLConnection(u, 404, errorBody));
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(404, response.getHttpStatusCode());
+            assertEquals(errorBody, response.getContentAsString());
+        }
+    }
+
+    // --- Timeout application tests (using open(URL) override to test production connect() path) ---
+
+    /**
+     * Mock HttpURLConnection that records timeout values.
+     */
+    class TimeoutRecordingMockHttpURLConnection extends HttpURLConnection {
+        int recordedConnectTimeout = -999;
+        int recordedReadTimeout = -999;
+
+        TimeoutRecordingMockHttpURLConnection(URL u) {
+            super(u);
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public int getResponseCode() {
+            return 200;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream("ok".getBytes());
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaderFields() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public void setConnectTimeout(int timeout) {
+            this.recordedConnectTimeout = timeout;
+            super.setConnectTimeout(timeout);
+        }
+
+        @Override
+        public void setReadTimeout(int timeout) {
+            this.recordedReadTimeout = timeout;
+            super.setReadTimeout(timeout);
+        }
+    }
+
+    /**
+     * CurlRequest subclass that overrides only open(URL) to inject a mock connection.
+     * This ensures the real connect() code path is exercised (timeout, headers, onConnect, etc.).
+     */
+    class OpenOverrideCurlRequest extends CurlRequest {
+        private final MockConnectionFactory connectionFactory;
+
+        OpenOverrideCurlRequest(Curl.Method method, String url, MockConnectionFactory factory) {
+            super(method, url);
+            this.connectionFactory = factory;
+        }
+
+        @Override
+        protected HttpURLConnection open(final URL u) throws IOException {
+            return connectionFactory.create(u);
+        }
+    }
+
+    @Test
+    public void test_TimeoutAppliedToConnection() throws Exception {
+        // ## Arrange ##
+        final TimeoutRecordingMockHttpURLConnection[] mockHolder = new TimeoutRecordingMockHttpURLConnection[1];
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> {
+            TimeoutRecordingMockHttpURLConnection mock = new TimeoutRecordingMockHttpURLConnection(u);
+            mockHolder[0] = mock;
+            return mock;
+        });
+        req.timeout(3000, 5000);
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertNotNull(mockHolder[0]);
+            assertEquals(3000, mockHolder[0].recordedConnectTimeout);
+            assertEquals(5000, mockHolder[0].recordedReadTimeout);
+        }
+    }
+
+    @Test
+    public void test_TimeoutNotSetWhenDefault() throws Exception {
+        // ## Arrange ##
+        final TimeoutRecordingMockHttpURLConnection[] mockHolder = new TimeoutRecordingMockHttpURLConnection[1];
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> {
+            TimeoutRecordingMockHttpURLConnection mock = new TimeoutRecordingMockHttpURLConnection(u);
+            mockHolder[0] = mock;
+            return mock;
+        });
+        // Do NOT set timeout - should remain at default
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertNotNull(mockHolder[0]);
+            // Should not have been called (still at initial -999)
+            assertEquals(-999, mockHolder[0].recordedConnectTimeout);
+            assertEquals(-999, mockHolder[0].recordedReadTimeout);
+        }
+    }
+
+    @Test
+    public void test_TimeoutZeroAppliedToConnection() throws Exception {
+        // ## Arrange ##
+        final TimeoutRecordingMockHttpURLConnection[] mockHolder = new TimeoutRecordingMockHttpURLConnection[1];
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> {
+            TimeoutRecordingMockHttpURLConnection mock = new TimeoutRecordingMockHttpURLConnection(u);
+            mockHolder[0] = mock;
+            return mock;
+        });
+        req.timeout(0, 0); // 0 means infinite timeout in HttpURLConnection
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertNotNull(mockHolder[0]);
+            assertEquals(0, mockHolder[0].recordedConnectTimeout);
+            assertEquals(0, mockHolder[0].recordedReadTimeout);
+        }
+    }
+
+    @Test
+    public void test_TimeoutWithOnConnectOverride() throws Exception {
+        // ## Arrange ##
+        final AtomicInteger onConnectReadTimeout = new AtomicInteger(-1);
+        final TimeoutRecordingMockHttpURLConnection[] mockHolder = new TimeoutRecordingMockHttpURLConnection[1];
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> {
+            TimeoutRecordingMockHttpURLConnection mock = new TimeoutRecordingMockHttpURLConnection(u);
+            mockHolder[0] = mock;
+            return mock;
+        });
+        req.timeout(3000, 5000);
+        // onConnect runs AFTER timeout, so it can override
+        req.onConnect((r, conn) -> {
+            conn.setReadTimeout(9999);
+            onConnectReadTimeout.set(conn.getReadTimeout());
+        });
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            // timeout() was applied first (3000, 5000)
+            // onConnect then overrode readTimeout to 9999
+            assertEquals(3000, mockHolder[0].recordedConnectTimeout);
+            assertEquals(9999, onConnectReadTimeout.get());
+        }
+    }
+
+    @Test
+    public void test_NegativeTimeoutTreatedAsUnset() throws Exception {
+        // ## Arrange ##
+        final TimeoutRecordingMockHttpURLConnection[] mockHolder = new TimeoutRecordingMockHttpURLConnection[1];
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> {
+            TimeoutRecordingMockHttpURLConnection mock = new TimeoutRecordingMockHttpURLConnection(u);
+            mockHolder[0] = mock;
+            return mock;
+        });
+        req.timeout(-2, -3); // Any negative value should be treated as "not set"
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertNotNull(mockHolder[0]);
+            // Negative values should not trigger setConnectTimeout/setReadTimeout
+            assertEquals(-999, mockHolder[0].recordedConnectTimeout);
+            assertEquals(-999, mockHolder[0].recordedReadTimeout);
+        }
+    }
+
+    // --- URL special characters through real connect() path ---
+
+    @Test
+    public void test_UrlWithSpecialCharacters_ThroughRealConnectPath() throws Exception {
+        // ## Arrange ##
+        // URLs with special characters (spaces, curly braces, pipes) must be accepted
+        // by the real connect() path using new URL()
+        String[] specialUrls = { "http://localhost:9200/{index}/_search", "http://example.com/path?q=a|b",
+                "http://example.com/page#section", "http://user:pass@example.com/path", "http://localhost:9200/_cluster/health" };
+
+        for (String specialUrl : specialUrls) {
+            final AtomicInteger openCalled = new AtomicInteger(0);
+            CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, specialUrl, u -> {
+                openCalled.incrementAndGet();
+                return new MockHttpURLConnection(u);
+            });
+
+            // ## Act ##
+            try (CurlResponse response = req.execute()) {
+                // ## Assert ##
+                // The request should reach open() without URL parsing failure
+                assertEquals("URL failed: " + specialUrl, 1, openCalled.get());
+                assertEquals(200, response.getHttpStatusCode());
+            }
+        }
+    }
+
+    // --- Success response tests ---
+
+    @Test
+    public void test_SuccessResponseWithBody_ReturnsBody() throws Exception {
+        // ## Arrange ##
+        CurlRequest req = new MockCurlRequest(Curl.Method.GET, "http://dummy");
+
+        // ## Act ##
+        try (CurlResponse response = req.execute()) {
+            // ## Assert ##
+            assertEquals(200, response.getHttpStatusCode());
+            assertNotNull(response.getContentAsString());
+        }
+    }
+
+    // --- Helper: MockConnectionFactory ---
+
+    interface MockConnectionFactory {
+        HttpURLConnection create(URL url) throws IOException;
     }
 }


### PR DESCRIPTION
## Summary
- Add `timeout(connectTimeout, readTimeout)` fluent API to `CurlRequest` for configuring HTTP connection timeouts
- Fix HEAD request handling and null error stream NPE in `RequestProcessor`
- Optimize `CurlResponse.getContentAsString()` to use `ContentCache.getContentAsBytes()` directly

## Changes Made
- **`CurlRequest`**: Added `connectTimeout`/`readTimeout` fields and `timeout()` method. Timeouts are applied to `HttpURLConnection` during `connect()` when values are >= 0
- **`CurlRequest.RequestProcessor`**: Moved HEAD method check before response code check to avoid reading input/error streams. Added null check for `getErrorStream()` to prevent NPE
- **`CurlRequest`**: Added `@SuppressWarnings("deprecation")` for `new URL()` constructor
- **`CurlResponse.getContentAsString()`**: Replaced `BufferedInputStream`/`ByteArrayOutputStream` streaming with direct `ContentCache.getContentAsBytes()` call. Added explicit null cache handling with proper error messages
- **`ContentCache`**: Added `isInMemory()` and `getContentAsBytes()` methods (defensive copy for in-memory, `Files.readAllBytes` for file-based)
- **Tests**: Added comprehensive tests for timeout API, HEAD requests, null error streams, error response bodies, URL special characters, `getContentAsString()` optimization, and `ContentCache` new methods

## Testing
- All new functionality covered by unit and integration tests
- Tests use mock `HttpURLConnection` subclasses to verify behavior without network access
- `mvn clean test` passes

## Breaking Changes
- None. All changes are backward-compatible.