### PR TITLE
chore(build): bump Maven plugins, commons-io, and gate GPG signing behind release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<release>17</release>
@@ -49,7 +49,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -58,7 +58,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -69,12 +69,12 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.26.0</version>
+				<version>2.29.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -128,23 +128,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -152,11 +138,37 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/test/java/org/codelibs/curl/io/IOIntegrationTest.java
+++ b/src/test/java/org/codelibs/curl/io/IOIntegrationTest.java
@@ -648,7 +648,8 @@ public class IOIntegrationTest {
         // ## Arrange ##
         String originalBody = "Hello, GZIP world!";
         byte[] gzipped = gzipCompress(originalBody);
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new GzipSuccessMockHttpURLConnection(u, gzipped));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new GzipSuccessMockHttpURLConnection(u, gzipped));
 
         // ## Act ##
         try (CurlResponse response = req.execute()) {
@@ -874,8 +875,8 @@ public class IOIntegrationTest {
     public void test_SynchronousExecute_ReturnsResponse() throws Exception {
         // ## Arrange ##
         String body = "sync response body";
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new OutputCapturingMockHttpURLConnection(u, body));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new OutputCapturingMockHttpURLConnection(u, body));
 
         // ## Act ##
         try (CurlResponse response = req.execute()) {
@@ -888,8 +889,8 @@ public class IOIntegrationTest {
     @Test
     public void test_SynchronousExecute_RestoresThreadPool() throws Exception {
         // ## Arrange ##
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new OutputCapturingMockHttpURLConnection(u, "ok"));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new OutputCapturingMockHttpURLConnection(u, "ok"));
         ForkJoinPool pool = new ForkJoinPool(1);
         req.threadPool(pool);
 
@@ -904,8 +905,8 @@ public class IOIntegrationTest {
         // We verify by running async execute which should use the pool
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<String> threadName = new AtomicReference<>();
-        CurlRequest req2 = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new OutputCapturingMockHttpURLConnection(u, "ok"));
+        CurlRequest req2 =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new OutputCapturingMockHttpURLConnection(u, "ok"));
         req2.threadPool(pool);
         req2.execute(response -> {
             threadName.set(Thread.currentThread().getName());
@@ -921,8 +922,8 @@ public class IOIntegrationTest {
     public void test_ExecuteWithListeners_Success() throws Exception {
         // ## Arrange ##
         String body = "listener response";
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new OutputCapturingMockHttpURLConnection(u, body));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new OutputCapturingMockHttpURLConnection(u, body));
         AtomicReference<String> receivedBody = new AtomicReference<>();
         AtomicInteger statusCode = new AtomicInteger();
 
@@ -1079,8 +1080,8 @@ public class IOIntegrationTest {
     public void test_LargeResponse_UsesFileBasedCache() throws Exception {
         // ## Arrange ##
         int responseSize = 2 * 1024 * 1024; // 2MB, exceeds default 1MB threshold
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new LargeResponseMockHttpURLConnection(u, responseSize));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new LargeResponseMockHttpURLConnection(u, responseSize));
 
         long tmpFilesBefore = countTmpFiles();
 
@@ -1105,8 +1106,8 @@ public class IOIntegrationTest {
     public void test_SmallThresholdResponse_UsesFileBasedCache() throws Exception {
         // ## Arrange ##
         String body = "small body but threshold is 0";
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new OutputCapturingMockHttpURLConnection(u, body));
+        CurlRequest req =
+                new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new OutputCapturingMockHttpURLConnection(u, body));
         req.threshold(0); // Force file-based caching
 
         long tmpFilesBefore = countTmpFiles();
@@ -1286,8 +1287,7 @@ public class IOIntegrationTest {
         // ## Arrange ##
         AtomicReference<CurlRequest> receivedRequest = new AtomicReference<>();
         AtomicReference<HttpURLConnection> receivedConnection = new AtomicReference<>();
-        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy",
-                u -> new TimeoutRecordingMockHttpURLConnection(u));
+        CurlRequest req = new OpenOverrideCurlRequest(Curl.Method.GET, "http://dummy", u -> new TimeoutRecordingMockHttpURLConnection(u));
         req.onConnect((r, conn) -> {
             receivedRequest.set(r);
             receivedConnection.set(conn);


### PR DESCRIPTION
## Summary
Routine maintenance bump of Maven build plugins and the `commons-io` runtime dependency. Also restructures GPG signing so it only runs under an explicit `release` profile, which avoids requiring a GPG key for normal local and CI builds.

## Changes Made
- **Build plugin bumps** (`pom.xml`):
  - `maven-compiler-plugin` 3.14.0 → 3.15.0
  - `maven-javadoc-plugin` 3.11.2 → 3.12.0
  - `maven-jar-plugin` 3.4.2 → 3.5.0
  - `maven-surefire-plugin` 3.5.3 → 3.5.5
  - `jacoco-maven-plugin` 0.8.13 → 0.8.14
  - `formatter-maven-plugin` 2.26.0 → 2.29.0
  - `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- **Dependency bump**: `commons-io` 2.19.0 → 2.22.0
- **GPG signing**: removed from the default `<build>` plugins and re-added inside a new `release` profile using `maven-gpg-plugin` 3.2.8 with `bestPractices=true`. Releases now need `mvn -Prelease …`; ordinary builds no longer attempt to sign.
- **Formatting**: reapplied the updated `formatter-maven-plugin` to `IOIntegrationTest.java`, which produced minor line-wrapping adjustments only (no behavior changes).

## Testing
- `mvn clean test` is expected to pass; no production code changes outside `pom.xml`.
- Release flow should be exercised with `mvn -Prelease …` once the GPG environment is available.

## Breaking Changes
- Anyone running a release build must now pass `-Prelease` to activate GPG signing. Previously signing happened on every `verify`.

## Additional Notes
- Please double-check the `central-publishing-maven-plugin` 0.7.0 → 0.10.0 jump for any config that may need to be updated alongside the version bump.
- The `IOIntegrationTest` diff is formatter-only; no test logic changed.